### PR TITLE
Force cmake to use gcc-10 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN cd Sparql-parser/build && \
 # change working directory
 WORKDIR /Sparql-parser/build
 # run cmake
-RUN cmake -DSPARQL_PARSER_BUILD_TESTS=ON ..
+RUN CC=gcc-10 CXX=g++-10 cmake -DSPARQL_PARSER_BUILD_TESTS=ON ..
 # build
 RUN make -j $(nproc)
 


### PR DESCRIPTION
This fixes the problem that the docker file does not build (because of DiceHash).